### PR TITLE
Fix: finalize tracking spec (cookie UU + redirect OUT, no JS)

### DIFF
--- a/includes/class-re-access-tracker.php
+++ b/includes/class-re-access-tracker.php
@@ -372,8 +372,17 @@ class RE_Access_Tracker {
      */
     private static function set_daily_uu_cookie($date) {
         $cookie_name = self::get_daily_cookie_name($date);
-        $expiry = strtotime('tomorrow', current_time('timestamp'));
-        setcookie($cookie_name, '1', $expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true);
+        $timezone = wp_timezone();
+        $end_of_day = (new DateTimeImmutable('now', $timezone))->setTime(23, 59, 59);
+        $expiry = $end_of_day->getTimestamp();
+        setcookie($cookie_name, '1', [
+            'expires' => $expiry,
+            'path' => COOKIEPATH,
+            'domain' => COOKIE_DOMAIN,
+            'secure' => is_ssl(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
         $_COOKIE[$cookie_name] = '1';
     }
 
@@ -384,7 +393,7 @@ class RE_Access_Tracker {
      * @return string
      */
     private static function get_daily_cookie_name($date) {
-        return 're_access_uu_' . str_replace('-', '', $date);
+        return 'reaccess_uu_' . str_replace('-', '', $date);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- RE:Access tracking must strictly follow the finalized spec: UU counted by a daily cookie, OUT measured only via redirect endpoints (no JS/AJAX), and tracking implemented in PHP only; this change updates the UU cookie handling to align with that requirement.

### Description
- Update UU cookie logic by changing the cookie name to `reaccess_uu_YYYYMMDD`, setting the expiry to the end of the current day using the WordPress timezone, and writing the cookie via `setcookie()` with `expires`, `path` set to `COOKIEPATH`, `domain` set to `COOKIE_DOMAIN`, `secure` set via `is_ssl()`, `httponly` enabled, `samesite` set to `Lax`, and updating `$_COOKIE` after set; these changes are in `includes/class-re-access-tracker.php`.
- This change is a specification-aligned replacement (rename/expiry/options) and not a new feature or UI change.
- 動作確認手順: 1) フロントアクセスで `pv` が増えること、 2) 初回アクセス時に `uu` が増え、同日再訪では増えないこと、 3) リダイレクト経由で `out` が増えること、 4) ページソースに RE:Access のトラッキングスクリプト（JS）が存在しないこと.

### Testing
- No automated tests were executed for this change (manual verification steps are provided above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af51a7ab883279878b83e207155f7)