### PR TITLE
Unify slot assignments: add link/rss slots to site registration (DB, admin UI, migration)

### DIFF
--- a/includes/class-re-access-database.php
+++ b/includes/class-re-access-database.php
@@ -28,6 +28,8 @@ class RE_Access_Database {
             site_name varchar(255) NOT NULL,
             site_url varchar(512) NOT NULL,
             rss_url varchar(512) DEFAULT '',
+            link_slots varchar(255) NOT NULL DEFAULT '',
+            rss_slots varchar(255) NOT NULL DEFAULT '',
             status varchar(20) DEFAULT 'pending',
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY  (id),


### PR DESCRIPTION
### Motivation

- Introduce per-site slot storage so link/RSS slot assignment is managed on the site record instead of scattered options. 
- Provide a single place (site add/edit) to assign slots and preserve backward compatibility by migrating legacy option-based assignments once. 
- Enforce exclusivity so each numeric slot can belong to only one site for link and RSS slots.

### Description

- Added `link_slots` and `rss_slots` columns to the `reaccess_sites` schema in `includes/class-re-access-database.php` so `dbDelta` can add the fields on existing installs. 
- Added checkboxes for `link_slots[]` and `rss_slots[]` (1..10) to the site add and edit forms in `admin/class-re-access-sites.php` and wired them into `handle_add_site` and `handle_update_site`. 
- Implemented sanitization, CSV serialization (`slots_to_csv`/`parse_slot_csv`), and helpers (`sanitize_slots`, `remove_slot_from_csv`) to validate inputs and keep CSV format (e.g. `"1,3,10"`). 
- Implemented exclusivity enforcement (`enforce_slot_exclusivity`) to remove selected slots from other sites on save, and a one-time migration (`migrate_slot_assignments`) that reads legacy options `re_access_link_slot_{n}` and `re_access_rss_slot_{n}` and merges them into site records, then sets the flag `re_access_migrated_slot_assignments`.
- Preserved existing security checks (`check_admin_referer` and `current_user_can`) and added defensive `isset`/`wp_unslash` usage so missing inputs are handled safely.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef0230e9c8327a752f6cb46935e2b)