### PR TITLE
Auto-resolve link/rss slots from sites; remove ranking templates and add thresholds/table sizing

### DIFF
--- a/admin/class-re-access-link-slots.php
+++ b/admin/class-re-access-link-slots.php
@@ -197,8 +197,9 @@ class RE_Access_Link_Slots {
             'site_id' => 0
         ], $atts);
         
-        $slot = max(1, min(10, (int)$atts['slot']));
-        $site_id = (int)$atts['site_id'];
+        $slot = absint($atts['slot']);
+        $slot = max(1, min(10, $slot));
+        $site_id = absint($atts['site_id']);
         
         // Get slot template
         $slot_data = self::get_slot_data($slot);
@@ -213,7 +214,10 @@ class RE_Access_Link_Slots {
                 $site_id
             ));
         } else {
-            $site = null;
+            $site = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM $sites_table WHERE status = 'approved' AND FIND_IN_SET(%d, link_slots) ORDER BY id DESC LIMIT 1",
+                $slot
+            ));
         }
         
         if (!$site) {

--- a/languages/re-access-ja.po
+++ b/languages/re-access-ja.po
@@ -220,6 +220,9 @@ msgstr "割り当てサイト"
 msgid "Ranking Settings"
 msgstr "ランキング設定"
 
+msgid "集計期間"
+msgstr "集計期間"
+
 msgid "Default Period"
 msgstr "デフォルト期間"
 
@@ -232,6 +235,18 @@ msgstr "流入を表示"
 msgid "Show OUT"
 msgstr "流出を表示"
 
+msgid "流入"
+msgstr "流入"
+
+msgid "流出"
+msgstr "流出"
+
+msgid "表示"
+msgstr "表示"
+
+msgid "何件以上表示"
+msgstr "何件以上表示"
+
 msgid "Show PV"
 msgstr "PVを表示"
 
@@ -240,6 +255,12 @@ msgstr "UUを表示"
 
 msgid "Table Width"
 msgstr "テーブル幅"
+
+msgid "テーブル幅(px)"
+msgstr "テーブル幅(px)"
+
+msgid "テーブル高さ(px)"
+msgstr "テーブル高さ(px)"
 
 msgid "Accent Color"
 msgstr "アクセントカラー"


### PR DESCRIPTION
### Motivation

- Remove per-slot "Assigned Site" maintenance and instead resolve slots automatically from `sites.link_slots` / `sites.rss_slots` while preserving backward-compatible `site_id` override. 
- Simplify ranking settings by removing HTML/CSS template features and provide simpler, safer table rendering with display thresholds and table sizing.

### Description

- Link slot shortcode now sanitizes `slot`/`site_id` with `absint`, clamps `slot` to 1–10, and if `site_id` is not provided selects an approved site using `FIND_IN_SET(%d, link_slots) ORDER BY id DESC LIMIT 1` (file: `admin/class-re-access-link-slots.php`).
- RSS slot shortcode now sanitizes `slot`/`site_id`, accepts `site_id` override, and if missing selects an approved site via `FIND_IN_SET(%d, rss_slots) ORDER BY id DESC LIMIT 1`; shortcodes return an empty string when no site/feed/items are available (file: `admin/class-re-access-rss-slots.php`).
- Ranking settings UI removed template editors and related defaults, added Japanese label for period, changed "Show IN/OUT" to localized labels, added boolean display check + threshold selects (`min_in`/`min_out` 0–50), and added `width`/`height` (px) inputs; rendering uses a table and applies filtering by thresholds, with a wrapper style applying `width` and `max-height` + `overflow:auto` (file: `admin/class-re-access-ranking.php`).
- Removed template-based rendering and CSS template handling from ranking code paths and updated default settings accordingly (file: `admin/class-re-access-ranking.php`).
- Updated Japanese translations in `languages/re-access-ja.po` for the new labels and table sizing strings; `.mo` file intentionally not modified.

### Testing

- No automated tests were executed for this change set.
- Basic static code edits were applied and files updated: `admin/class-re-access-link-slots.php`, `admin/class-re-access-rss-slots.php`, `admin/class-re-access-ranking.php`, and `languages/re-access-ja.po`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef5def0188327bead0ae65383b31b)