### PR TITLE
Use real link/RSS previews and limit slots to 8

### DIFF
--- a/admin/class-re-access-ranking.php
+++ b/admin/class-re-access-ranking.php
@@ -247,7 +247,7 @@ class RE_Access_Ranking {
             }
         } else {
             $colspan = 2 + ($settings['show_in'] ? 1 : 0) + ($settings['show_out'] ? 1 : 0);
-            $output .= '<tr><td colspan="' . $colspan . '" style="padding: 10px; border: 1px solid #ddd; text-align: center;">' . esc_html__('No data available', 're-access') . '</td></tr>';
+            $output .= '<tr><td colspan="' . $colspan . '" style="padding: 10px; border: 1px solid #ddd; text-align: center;">' . esc_html__('No data available', 're-access') . '<br><span class="description">' . esc_html__('計測データがまだ無いため表示されません。アクセス計測後に反映されます。', 're-access') . '</span></td></tr>';
         }
         
         $output .= '</tbody>';

--- a/admin/class-re-access-sites.php
+++ b/admin/class-re-access-sites.php
@@ -116,7 +116,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $link_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -127,7 +127,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $rss_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -167,7 +167,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -178,7 +178,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -450,7 +450,7 @@ class RE_Access_Sites {
         $sanitized = [];
         foreach ($slots as $slot) {
             $value = absint(wp_unslash($slot));
-            if ($value >= 1 && $value <= 10) {
+            if ($value >= 1 && $value <= 8) {
                 $sanitized[] = $value;
             }
         }
@@ -500,7 +500,7 @@ class RE_Access_Sites {
     private static function remove_slot_from_csv($csv, $slot) {
         $slots = self::parse_slot_csv($csv);
         $slot = absint($slot);
-        if ($slot < 1 || $slot > 10) {
+        if ($slot < 1 || $slot > 8) {
             return self::slots_to_csv($slots);
         }
 
@@ -566,7 +566,7 @@ class RE_Access_Sites {
         $link_map = [];
         $rss_map = [];
 
-        for ($slot = 1; $slot <= 10; $slot++) {
+        for ($slot = 1; $slot <= 8; $slot++) {
             $link_option = get_option('re_access_link_slot_' . $slot);
             $rss_option = get_option('re_access_rss_slot_' . $slot);
 


### PR DESCRIPTION
### Motivation
- 管理画面のスロット数を統一して誤使用を防ぎ、リンク／RSSプレビューをサンプル表示から実際の出力に切替えて管理画面の一貫性を向上します。
- ランキングプレビューでデータがないときの説明を明記して管理者に状態をわかりやすく伝えます。

### Description
- 管理用スロット上限を 10 → 8 に変更し、タブ表示／チェックボックス／入力サニタイズ／移行ループを 1..8 に制限するように `admin/class-re-access-link-slots.php`, `admin/class-re-access-rss-slots.php`, `admin/class-re-access-sites.php` を更新しました.
- 管理画面のプレビュー出力をサンプル文字列から実表示へ変更し、プレビュー実行はそれぞれ `do_shortcode('[reaccess_link_slot slot="X"]')` と `do_shortcode('[reaccess_rss_slot slot="X"]')` を使うようにしました（ショートコードが空を返す場合の管理画面向け案内文は日本語で表示します）。
- ショートコード/保存/サニタイズ処理にスロット範囲チェック（1..8）を追加し、範囲外スロット（例: 9/10）は管理画面操作で保存されないよう無視、ショートコード呼び出しでは空文字を返す挙動にしています。
- ランキングの「データ無し」行に補足説明の日本語文を追加しました: 「計測データがまだ無いため表示されません。アクセス計測後に反映されます。」
- 変更対象ファイル: `admin/class-re-access-link-slots.php`, `admin/class-re-access-rss-slots.php`, `admin/class-re-access-sites.php`, `admin/class-re-access-ranking.php`.
- 管理画面向けの新規案内文（表示用）はすべて日本語で追加しました:  
  - リンクプレビュー無割当時: 「このスロットに割り当てられたサイトがありません。サイト編集でスロットを割り当ててください。」
  - RSSプレビュー失敗時: 「RSSが取得できません。サイトのRSS URLとスロット割り当てを確認してください。」

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efbf73638832784f6cbfa282ade16)