### PR TITLE
Allow multiple sites per slot

### DIFF
--- a/admin/class-re-access-sites.php
+++ b/admin/class-re-access-sites.php
@@ -322,9 +322,7 @@ class RE_Access_Sites {
             'status' => 'pending'
         ]);
 
-        if (!empty($wpdb->insert_id)) {
-            self::enforce_slot_exclusivity((int) $wpdb->insert_id, $link_slots, $rss_slots);
-        }
+        // Slot exclusivity removed: multiple sites can share the same slot.
         
         // Create notice
         RE_Access_Notices::add_notice('site_registered', sprintf(
@@ -435,7 +433,7 @@ class RE_Access_Sites {
             'rss_slots' => self::slots_to_csv($rss_slots),
         ], ['id' => $site_id]);
 
-        self::enforce_slot_exclusivity($site_id, $link_slots, $rss_slots);
+        // Slot exclusivity removed: multiple sites can share the same slot.
         
         // Clear approved sites cache
         delete_transient('re_access_approved_sites');


### PR DESCRIPTION
### Motivation
- Slots should be shareable so multiple approved sites can be assigned the same slot and shortcodes should render all assigned sites instead of only one.

### Description
- Stop enforcing slot exclusivity by removing calls to `enforce_slot_exclusivity()` on site add/update so slot assignments are no longer removed from other sites (`admin/class-re-access-sites.php`).
- Update `shortcode_link_slot` to fetch multiple sites via `get_results()` (SQL: `status='approved' AND FIND_IN_SET(slot, link_slots)` ordered by `id DESC` with no `LIMIT 1`) and loop the results to render each site using the slot template while preserving the `site_id` override (`admin/class-re-access-link-slots.php`).
- Update `shortcode_rss_slot` to fetch multiple sites similarly, skip sites with empty `rss_url`, fetch each site's feed individually (skip if feed items are empty), emit CSS only if any feed items are produced, and return empty when nothing is available; `site_id` still forces single-site behavior for compatibility (`admin/class-re-access-rss-slots.php`).
- Adjusted filter payloads to pass the set of sites or feed-items-per-site to callers (`apply_filters` signatures updated).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f00f9161c832791d7fd3efcca8102)