### PR TITLE
Allow selecting link/RSS slots 1–10 in site add/edit and migrate legacy assignments

### DIFF
--- a/admin/class-re-access-sites.php
+++ b/admin/class-re-access-sites.php
@@ -116,7 +116,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $link_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -127,7 +127,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $rss_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -167,7 +167,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -178,7 +178,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -456,7 +456,7 @@ class RE_Access_Sites {
         $slots = wp_unslash($slots);
         $slots = array_map('absint', $slots);
         $slots = array_filter($slots, static function ($value) {
-            return $value >= 1 && $value <= 8;
+            return $value >= 1 && $value <= 10;
         });
         $slots = array_values(array_unique($slots));
         sort($slots, SORT_NUMERIC);
@@ -503,7 +503,7 @@ class RE_Access_Sites {
     private static function remove_slot_from_csv($csv, $slot) {
         $slots = self::parse_slot_csv($csv);
         $slot = absint($slot);
-        if ($slot < 1 || $slot > 8) {
+        if ($slot < 1 || $slot > 10) {
             return self::slots_to_csv($slots);
         }
 
@@ -569,7 +569,7 @@ class RE_Access_Sites {
         $link_map = [];
         $rss_map = [];
 
-        for ($slot = 1; $slot <= 8; $slot++) {
+        for ($slot = 1; $slot <= 10; $slot++) {
             $link_option = get_option('re_access_link_slot_' . $slot);
             $rss_option = get_option('re_access_rss_slot_' . $slot);
 


### PR DESCRIPTION
### Motivation
- Support assigning up to 10 link and RSS slots from the site add/edit UI and migrate any existing legacy assignments into the site records.
- Keep backward compatibility by performing a one-time migration from legacy options into the `reaccess_sites` table.

### Description
- Expanded the site add/edit forms' slot checkboxes from `1..8` to `1..10` in `admin/class-re-access-sites.php` so `name="link_slots[]"` and `name="rss_slots[]"` can submit up to 10 selections. 
- Updated slot sanitization and validation to accept the range `1..10` by changing `sanitize_slots()` and `remove_slot_from_csv()` in `admin/class-re-access-sites.php`.
- Extended the legacy migration loop in `migrate_slot_assignments()` to scan `re_access_link_slot_{n}` / `re_access_rss_slot_{n}` for `n=1..10` and merge results into each site's `link_slots`/`rss_slots` CSV fields, then set the migration flag `re_access_migrated_slot_assignments` to prevent re-running. 
- Kept existing security checks (`current_user_can` and `check_admin_referer`) and CSV storage behavior (`slots_to_csv` / `parse_slot_csv`) unchanged so existing installs remain compatible.

### Testing
- No automated tests were run for this change.
- Basic static verification and commit were performed on the modified file `admin/class-re-access-sites.php` with no runtime tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f05204d74832785bac3f6e81c5d73)