### PR TITLE
スロット1〜8統一とLink/RSSの自動割当・還元優先度・RSS混合表示の実装

### DIFF
--- a/admin/class-re-access-link-slots.php
+++ b/admin/class-re-access-link-slots.php
@@ -10,6 +10,8 @@ if (!defined('WPINC')) {
 }
 
 class RE_Access_Link_Slots {
+
+    private const MAX_SITES_PER_SLOT = 3;
     
     /**
      * Render link slots page
@@ -216,6 +218,20 @@ class RE_Access_Link_Slots {
                 "SELECT * FROM $sites_table WHERE status = 'approved' AND FIND_IN_SET(%d, link_slots) ORDER BY id DESC",
                 $slot
             ));
+            if (!empty($sites) && class_exists('RE_Access_Ranking')) {
+                $priorities = RE_Access_Ranking::get_return_priorities();
+                usort($sites, static function ($a, $b) use ($priorities) {
+                    $priority_a = $priorities[$a->id] ?? 0;
+                    $priority_b = $priorities[$b->id] ?? 0;
+                    if ($priority_a === $priority_b) {
+                        return $b->id <=> $a->id;
+                    }
+                    return $priority_b <=> $priority_a;
+                });
+            }
+            if (count($sites) > self::MAX_SITES_PER_SLOT) {
+                $sites = array_slice($sites, 0, self::MAX_SITES_PER_SLOT);
+            }
         }
         
         if (empty($sites)) {

--- a/admin/class-re-access-sites.php
+++ b/admin/class-re-access-sites.php
@@ -116,7 +116,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $link_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -127,7 +127,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>" <?php checked(in_array($slot, $rss_selected, true)); ?>>
                                             <?php echo esc_html($slot); ?>
@@ -167,7 +167,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('Link Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="link_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -178,7 +178,7 @@ class RE_Access_Sites {
                             <tr>
                                 <th><?php esc_html_e('RSS Slot Assignments', 're-access'); ?></th>
                                 <td>
-                                    <?php for ($slot = 1; $slot <= 10; $slot++): ?>
+                                    <?php for ($slot = 1; $slot <= 8; $slot++): ?>
                                         <label style="margin-right: 10px;">
                                             <input type="checkbox" name="rss_slots[]" value="<?php echo esc_attr($slot); ?>">
                                             <?php echo esc_html($slot); ?>
@@ -456,7 +456,7 @@ class RE_Access_Sites {
         $slots = wp_unslash($slots);
         $slots = array_map('absint', $slots);
         $slots = array_filter($slots, static function ($value) {
-            return $value >= 1 && $value <= 10;
+            return $value >= 1 && $value <= 8;
         });
         $slots = array_values(array_unique($slots));
         sort($slots, SORT_NUMERIC);
@@ -503,7 +503,7 @@ class RE_Access_Sites {
     private static function remove_slot_from_csv($csv, $slot) {
         $slots = self::parse_slot_csv($csv);
         $slot = absint($slot);
-        if ($slot < 1 || $slot > 10) {
+        if ($slot < 1 || $slot > 8) {
             return self::slots_to_csv($slots);
         }
 


### PR DESCRIPTION
### Motivation
- スロット数を1〜8に統一して割当の整合性を保つため。 
- 管理画面プレビューは実表示を優先し、運用中のデータで確認できるようにするため。 
- 受け取った/返した（IN/OUT）の差分を元に「返すべき相手」を優先表示し、還元を自動化するため。 
- RSSは複数サイトを混ぜて表示し、時系列で新着を正しく見せるため。 

### Description
- サイト編集画面のスロットUIと入力検証を `1..8` に統一し、既存の9/10は無視する挙動に変更（`admin/class-re-access-sites.php`）。
- ランキングに `get_return_priorities()` を追加し、期間内の `IN - OUT` を `max(0, IN-OUT)` として算出・ transient で短時間キャッシュする実装を追加（`admin/class-re-access-ranking.php`）。
- リンクスロットの自動解決を導入し、サイト候補を `sites` テーブルから取得して還元優先度でソート、同順位は `id DESC`、最大 `3` 件まで表示するようにした（互換で `site_id` 指定はそのまま動作）（`admin/class-re-access-link-slots.php`）。
- RSSスロットで複数サイト分のフィードを取得して URL 単位で重複を排除し、タイムスタンプで降順マージして上位 `item_count` 件を表示するロジックを追加し、RSS取得とキャッシュは既存の仕組みを流用（`admin/class-re-access-rss-slots.php`）。
- 管理画面の文言は日本語を維持し、プレビューは既存の `do_shortcode` を用いて実表示を優先する挙動に準拠。 

### Testing
- 自動テストは実行していません。変更はリポジトリ内の該当ファイル差分と簡易静的確認により確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f06630e908327af71d97593560c2d)