### PR TITLE
Add URL alias management and unregistered referrer tracking

### DIFF
--- a/admin/class-re-access-unregistered-urls.php
+++ b/admin/class-re-access-unregistered-urls.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Unregistered referrer URLs list
+ *
+ * @package ReAccess
+ */
+
+if (!defined('WPINC')) {
+    die;
+}
+
+class RE_Access_Unregistered_URLs {
+
+    /**
+     * Render unregistered URLs page.
+     */
+    public static function render() {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('You do not have permission to access this page.', 're-access'));
+        }
+
+        $period = isset($_GET['period']) ? (int) $_GET['period'] : 7;
+        if (!in_array($period, [7, 30], true)) {
+            $period = 7;
+        }
+
+        $rows = self::get_unregistered_rows($period);
+        $sites_url = admin_url('admin.php?page=re-access-sites&status=approved');
+        ?>
+        <div class="wrap re-access-unregistered-urls">
+            <h1><?php echo esc_html__('未登録URL', 're-access'); ?></h1>
+
+            <div style="background: #fff; padding: 20px; border: 1px solid #ccc; border-radius: 5px; margin: 20px 0;">
+                <form method="get">
+                    <input type="hidden" name="page" value="re-access-unregistered-urls">
+                    <label for="re-access-period"><?php echo esc_html__('期間', 're-access'); ?></label>
+                    <select id="re-access-period" name="period">
+                        <option value="7" <?php selected($period, 7); ?>><?php echo esc_html__('直近7日', 're-access'); ?></option>
+                        <option value="30" <?php selected($period, 30); ?>><?php echo esc_html__('直近30日', 're-access'); ?></option>
+                    </select>
+                    <input type="submit" class="button" value="<?php echo esc_attr__('表示', 're-access'); ?>">
+                </form>
+            </div>
+
+            <div style="background: #fff; padding: 20px; border: 1px solid #ccc; border-radius: 5px;">
+                <h2><?php echo esc_html__('未登録リファラ一覧', 're-access'); ?></h2>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th><?php echo esc_html__('ホスト', 're-access'); ?></th>
+                            <th><?php echo esc_html__('合計', 're-access'); ?></th>
+                            <th><?php echo esc_html__('最終検知', 're-access'); ?></th>
+                            <th><?php echo esc_html__('操作', 're-access'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (!empty($rows)) : ?>
+                            <?php foreach ($rows as $row) : ?>
+                                <?php
+                                $alias_url = add_query_arg(
+                                    ['alias' => $row->ref_host],
+                                    $sites_url
+                                );
+                                ?>
+                                <tr>
+                                    <td><?php echo esc_html($row->ref_host); ?></td>
+                                    <td><?php echo esc_html(number_format_i18n((int) $row->total_count)); ?></td>
+                                    <td><?php echo esc_html($row->last_seen); ?></td>
+                                    <td>
+                                        <a class="button button-small" href="<?php echo esc_url($alias_url); ?>">
+                                            <?php echo esc_html__('サイト編集へ', 're-access'); ?>
+                                        </a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else : ?>
+                            <tr>
+                                <td colspan="4"><?php echo esc_html__('未登録リファラはありません。', 're-access'); ?></td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Fetch aggregated unregistered referrer rows.
+     *
+     * @param int $period
+     * @return array
+     */
+    private static function get_unregistered_rows($period) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'reaccess_unregistered_in';
+        $interval = max(1, (int) $period) - 1;
+
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT ref_host, SUM(count) as total_count, MAX(last_seen) as last_seen
+             FROM $table
+             WHERE date >= DATE_SUB(CURDATE(), INTERVAL %d DAY)
+             GROUP BY ref_host
+             ORDER BY total_count DESC, last_seen DESC",
+            $interval
+        ));
+
+        return $rows ?: [];
+    }
+}

--- a/includes/class-re-access-database.php
+++ b/includes/class-re-access-database.php
@@ -30,6 +30,7 @@ class RE_Access_Database {
             rss_url varchar(512) DEFAULT '',
             link_slots varchar(255) NOT NULL DEFAULT '',
             rss_slots varchar(255) NOT NULL DEFAULT '',
+            url_aliases varchar(2048) NOT NULL DEFAULT '',
             status varchar(20) DEFAULT 'pending',
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY  (id),
@@ -82,6 +83,22 @@ class RE_Access_Database {
             KEY type (type)
         ) $charset_collate;";
         dbDelta($sql_notice);
+
+        // Unregistered inbound referrers (daily counts)
+        $table_unregistered = $wpdb->prefix . 'reaccess_unregistered_in';
+        $sql_unregistered = "CREATE TABLE $table_unregistered (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            date date NOT NULL,
+            ref_host varchar(255) NOT NULL,
+            count int(11) DEFAULT 0,
+            first_seen datetime DEFAULT CURRENT_TIMESTAMP,
+            last_seen datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY date_ref_host (date, ref_host),
+            KEY ref_host (ref_host),
+            KEY date (date)
+        ) $charset_collate;";
+        dbDelta($sql_unregistered);
     }
 
     /**
@@ -96,6 +113,7 @@ class RE_Access_Database {
             'reaccess_daily',
             'reaccess_site_daily',
             'reaccess_notice',
+            'reaccess_unregistered_in',
         ];
 
         foreach ($table_names as $table_name) {

--- a/re-access.php
+++ b/re-access.php
@@ -53,6 +53,7 @@ $maybe_require('admin/class-re-access-ranking.php');
 $maybe_require('admin/class-re-access-link-slots.php');
 $maybe_require('admin/class-re-access-rss-slots.php');
 $maybe_require('admin/class-re-access-import-export.php');
+$maybe_require('admin/class-re-access-unregistered-urls.php');
 
 /**
  * Activation hook: Create tables and save plugin version
@@ -225,6 +226,17 @@ function re_access_admin_menu() {
             'manage_options',
             're-access-import-export',
             ['RE_Access_Import_Export', 'render']
+        );
+    }
+
+    if (class_exists('RE_Access_Unregistered_URLs') && method_exists('RE_Access_Unregistered_URLs', 'render')) {
+        add_submenu_page(
+            're-access',
+            __('未登録URL', 're-access'),
+            __('未登録URL', 're-access'),
+            'manage_options',
+            're-access-unregistered-urls',
+            ['RE_Access_Unregistered_URLs', 'render']
         );
     }
     


### PR DESCRIPTION
### Motivation
- 支払い元や別名ドメインからの流入を既存のエイリアス仕組みで統合し、IN計測に反映させるため。
- 登録サイトに一致しないリファラ（未登録リファラ）を把握して容易に登録へ繋げられるUIを管理画面に追加するため。

### Description
- 管理画面のサイト追加/編集フォームに『統合URL（別名URL）』のテキストエリアを追加し、1行1URL/ドメインで入力可能にしました（日本語説明を表示）。
- sites テーブルに `url_aliases varchar(2048) NOT NULL DEFAULT ''` 列を追加し、サイト側でエイリアスを保持します（CSV 格納）。
- 入力の正規化は `wp_unslash` → `trim` → `RE_Access_Database::normalize_url` → 空・重複・canonical 除外、最大件数制限を行い保存します（実装: `admin/class-re-access-sites.php`）。
- `re_access_url_aliases` オプション（既存）へ alias->canonical マップを差分で反映・削除する仕組みを追加し、resolve ロジックと整合します（編集/削除時に差分で更新）。
- トラッカーを拡張し、登録サイトに一致しなかったリファラをホスト単位で日次集計して `{$wpdb->prefix}reaccess_unregistered_in` テーブルへ upsert するようにしました（実装: `includes/class-re-access-tracker.php`）。
- DB 作成ロジックに `url_aliases` カラムと未登録リファラ用テーブルを追加（`includes/class-re-access-database.php` の `create_tables`/`drop_tables` を更新）。
- 管理メニューに「未登録URL」ページを追加し、直近7日/30日フィルタとホスト別合計・最終検知表示、行ごとに「サイト編集へ」リンク（エイリアスプリセット用の `alias` クエリ）を用意しました（新規ファイル: `admin/class-re-access-unregistered-urls.php`、メニュー追加: `re-access.php`）。
- 管理操作には既存の `check_admin_referer` と `current_user_can` を維持しています。

### Testing
- 自動化テストは実行していません（ローカルでの WordPress 実行検証は未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f0ee6ddc48327b484d8e41aba1dde)