### PR TITLE
Remove manual slot assignments and auto-select sites by IN-OUT return need

### DIFF
--- a/admin/class-re-access-link-slots.php
+++ b/admin/class-re-access-link-slots.php
@@ -192,26 +192,7 @@ class RE_Access_Link_Slots {
      * @return string
      */
     private static function get_preview_notice($slot) {
-        global $wpdb;
-        $sites_table = $wpdb->prefix . 'reaccess_sites';
-
-        $assigned_count = (int) $wpdb->get_var($wpdb->prepare(
-            "SELECT COUNT(*) FROM $sites_table WHERE FIND_IN_SET(%d, link_slots)",
-            $slot
-        ));
-        if ($assigned_count === 0) {
-            return 'このスロットに割り当てられたサイトがありません。サイト編集でスロットを割り当ててください。';
-        }
-
-        $approved_count = (int) $wpdb->get_var($wpdb->prepare(
-            "SELECT COUNT(*) FROM $sites_table WHERE status = 'approved' AND FIND_IN_SET(%d, link_slots)",
-            $slot
-        ));
-        if ($approved_count === 0) {
-            return '承認（approved）されていないサイトは表示されません。';
-        }
-
-        return 'このスロットに表示できるサイトがありません。サイトの承認状況とスロット割り当てを確認してください。';
+        return '表示できる承認済みサイトがありません。';
     }
     
     /**
@@ -243,29 +224,10 @@ class RE_Access_Link_Slots {
             ));
             $sites = $site ? [$site] : [];
         } else {
-            $sites = $wpdb->get_results($wpdb->prepare(
-                "SELECT * FROM $sites_table WHERE status = 'approved' AND FIND_IN_SET(%d, link_slots) ORDER BY id DESC",
-                $slot
-            ));
-            if (!empty($sites) && class_exists('RE_Access_Ranking')) {
-                $priorities = RE_Access_Ranking::get_return_priorities();
-                $seed = date_i18n('Y-m-d', current_time('timestamp')) . '|' . $slot;
-                usort($sites, static function ($a, $b) use ($priorities, $seed) {
-                    $priority_a = $priorities[$a->id] ?? 0;
-                    $priority_b = $priorities[$b->id] ?? 0;
-                    if ($priority_a === $priority_b) {
-                        $tie_a = crc32($seed . '|' . $a->id);
-                        $tie_b = crc32($seed . '|' . $b->id);
-                        if ($tie_a === $tie_b) {
-                            return $b->id <=> $a->id;
-                        }
-                        return $tie_a <=> $tie_b;
-                    }
-                    return $priority_b <=> $priority_a;
-                });
-            }
-            if (count($sites) > self::MAX_SITES_PER_SLOT) {
-                $sites = array_slice($sites, 0, self::MAX_SITES_PER_SLOT);
+            if (class_exists('RE_Access_Return')) {
+                $sites = RE_Access_Return::get_prioritized_sites('link', self::MAX_SITES_PER_SLOT);
+            } else {
+                $sites = [];
             }
         }
         

--- a/admin/class-re-access-ranking.php
+++ b/admin/class-re-access-ranking.php
@@ -176,6 +176,16 @@ class RE_Access_Ranking {
     }
 
     /**
+     * Get aggregation period (days) from settings.
+     *
+     * @return int
+     */
+    public static function get_aggregation_period() {
+        $settings = self::get_settings();
+        return max(1, (int) $settings['period']);
+    }
+
+    /**
      * Get return priorities for sites based on IN-OUT over a period.
      *
      * @param int|null $period

--- a/includes/class-re-access-return.php
+++ b/includes/class-re-access-return.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Return prioritization logic (IN-OUT).
+ *
+ * @package ReAccess
+ */
+
+if (!defined('WPINC')) {
+    die;
+}
+
+class RE_Access_Return {
+    private const CACHE_TTL = 20 * MINUTE_IN_SECONDS;
+    private const SHUFFLE_POOL_SIZE = 10;
+
+    /**
+     * Cached results for the current request.
+     *
+     * @var array<string,array>
+     */
+    private static $cached = [];
+
+    /**
+     * Get prioritized sites based on return needs (IN - OUT).
+     *
+     * @param string $type 'link' or 'rss'.
+     * @param int $limit
+     * @return array
+     */
+    public static function get_prioritized_sites($type, $limit) {
+        $limit = absint($limit);
+        if ($limit === 0) {
+            return [];
+        }
+
+        $type = $type === 'rss' ? 'rss' : 'link';
+        $sites = self::get_sites_with_priorities();
+
+        if ($type === 'rss') {
+            $sites = array_values(array_filter($sites, static function ($site) {
+                return !empty($site->rss_url);
+            }));
+        }
+
+        if (empty($sites)) {
+            return [];
+        }
+
+        usort($sites, static function ($a, $b) {
+            $priority_a = (int) ($a->return_need ?? 0);
+            $priority_b = (int) ($b->return_need ?? 0);
+            if ($priority_a === $priority_b) {
+                return $b->id <=> $a->id;
+            }
+            return $priority_b <=> $priority_a;
+        });
+
+        $pool_size = min(self::SHUFFLE_POOL_SIZE, count($sites));
+        $pool = array_slice($sites, 0, $pool_size);
+        if (count($pool) > 1) {
+            shuffle($pool);
+        }
+
+        $selected = array_slice($pool, 0, $limit);
+        if (count($selected) < $limit && $pool_size < count($sites)) {
+            $selected = array_merge(
+                $selected,
+                array_slice($sites, $pool_size, $limit - count($selected))
+            );
+        }
+
+        return $selected;
+    }
+
+    /**
+     * Build site list with return priorities (IN-OUT).
+     *
+     * @return array
+     */
+    private static function get_sites_with_priorities() {
+        if (isset(self::$cached['sites'])) {
+            return self::$cached['sites'];
+        }
+
+        $period = 7;
+        if (class_exists('RE_Access_Ranking') && method_exists('RE_Access_Ranking', 'get_aggregation_period')) {
+            $period = (int) RE_Access_Ranking::get_aggregation_period();
+        }
+        $period = max(1, $period);
+        $cache_key = 're_access_return_sites_' . $period;
+
+        $cached = get_transient($cache_key);
+        if (is_array($cached)) {
+            self::$cached['sites'] = $cached;
+            return $cached;
+        }
+
+        global $wpdb;
+        $sites_table = $wpdb->prefix . 'reaccess_sites';
+        $tracking_table = $wpdb->prefix . 'reaccess_site_daily';
+        $interval = $period - 1;
+
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT s.id, s.site_name, s.site_url, s.rss_url,
+                COALESCE(SUM(t.`in`), 0) as total_in,
+                COALESCE(SUM(t.`out`), 0) as total_out
+             FROM $sites_table s
+             LEFT JOIN $tracking_table t
+               ON s.id = t.site_id
+              AND t.date >= DATE_SUB(CURDATE(), INTERVAL %d DAY)
+             WHERE s.status = 'approved'
+             GROUP BY s.id",
+            $interval
+        ));
+
+        $sites = [];
+        foreach ($rows as $row) {
+            $row->return_need = max(0, (int) $row->total_in - (int) $row->total_out);
+            $sites[] = $row;
+        }
+
+        set_transient($cache_key, $sites, self::CACHE_TTL);
+        self::$cached['sites'] = $sites;
+
+        return $sites;
+    }
+}

--- a/re-access.php
+++ b/re-access.php
@@ -47,6 +47,7 @@ $maybe_require = function (string $path) {
 $maybe_require('includes/class-re-access-database.php');
 $maybe_require('includes/class-re-access-tracker.php');
 $maybe_require('includes/class-re-access-notices.php');
+$maybe_require('includes/class-re-access-return.php');
 $maybe_require('admin/class-re-access-dashboard.php');
 $maybe_require('admin/class-re-access-sites.php');
 $maybe_require('admin/class-re-access-ranking.php');


### PR DESCRIPTION
### Motivation
- Remove manual "リンクスロット割り当て" / "RSSスロット割り当て" from site editor and stop saving/updating those fields while keeping DB columns for compatibility. 
- Automatically decide which approved sites to show in link/RSS slots based on return need (IN - OUT) so the plugin returns access proportional to incoming traffic. 
- Keep admin/frontend Japanese messages and ensure RSS items without images render as text-only links. 

### Description
- Removed slot assignment UI and all save/parse/enforcement/migration code related to `link_slots` / `rss_slots` from `admin/class-re-access-sites.php`, preserving DB columns but stopping their use on save. 
- Added `includes/class-re-access-return.php` implementing `RE_Access_Return::get_prioritized_sites($type, $limit)` which computes return-need = max(0, IN - OUT) over the aggregation period, caches results (transient), filters for RSS when requested, sorts by need and lightly shuffles the top pool to avoid bias. 
- Updated link and RSS slot handlers to use the new return logic when `site_id` is not specified (`admin/class-re-access-link-slots.php`, `admin/class-re-access-rss-slots.php`), while preserving `site_id` override for backward compatibility and updating preview messages. 
- Exposed aggregation period accessor in `admin/class-re-access-ranking.php` and loaded the new return class in `re-access.php`. 
- Left RSS item image handling as-is so items without `image` produce text-only output (placeholder `[rr_item_image]` is removed when empty). 

### Testing
- Automated tests: none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a87d8c348327aaea3b01acc6bd95)