### PR TITLE
リンクスロット割当の追加とRSSスロットのインポート削除

### DIFF
--- a/admin/class-re-access-import-export.php
+++ b/admin/class-re-access-import-export.php
@@ -518,10 +518,6 @@ class RE_Access_Import_Export {
             $data['link_slots'] = self::sanitize_slot_value($site['link_slots'] ?? '');
         }
 
-        if (in_array('rss_slots', $columns, true)) {
-            $data['rss_slots'] = self::sanitize_slot_value($site['rss_slots'] ?? '');
-        }
-
         if (in_array('status', $columns, true)) {
             $data['status'] = sanitize_text_field($site['status'] ?? 'approved');
         }

--- a/admin/class-re-access-link-slots.php
+++ b/admin/class-re-access-link-slots.php
@@ -192,7 +192,7 @@ class RE_Access_Link_Slots {
      * @return string
      */
     private static function get_preview_notice($slot) {
-        return '表示できる承認済みサイトがありません。';
+        return 'このスロットに割り当てられたサイトがありません。サイト編集でリンクスロットを割り当ててください。';
     }
     
     /**
@@ -224,11 +224,10 @@ class RE_Access_Link_Slots {
             ));
             $sites = $site ? [$site] : [];
         } else {
-            if (class_exists('RE_Access_Return')) {
-                $sites = RE_Access_Return::get_prioritized_sites('link', self::MAX_SITES_PER_SLOT);
-            } else {
-                $sites = [];
-            }
+            $sites = $wpdb->get_results($wpdb->prepare(
+                "SELECT * FROM $sites_table WHERE status = 'approved' AND FIND_IN_SET(%d, link_slots) ORDER BY id DESC LIMIT 1",
+                $slot
+            ));
         }
         
         if (empty($sites)) {


### PR DESCRIPTION
### Motivation
- サイト登録/編集で手動のリンクスロット割当を可能にし、フロントでは手動割当に基づいて表示するための変更。 
- 既存の `rss_slots` のUI/保存参照を撤去し、RSSは割当無しで自動選定する既存ロジックを優先するため。 

### Description
- サイト編集／追加フォームに `リンクスロット割り当て` のチェックボックスを追加し、`admin/class-re-access-sites.php` にて `link_slots` を配列→`absint`→範囲チェック(1..8)→重複排除→昇順→CSV で保存する処理を導入（`sanitize_slot_assignments` / `parse_slots_csv` を追加）。
- リンクスロット表示ショートコードを `admin/class-re-access-link-slots.php` 側で `site_id` 未指定時に `status='approved' AND FIND_IN_SET(%d, link_slots)` で候補を取得するよう変更し、管理画面プレビューのメッセージを改善。 
- サイトインポート処理 `admin/class-re-access-import-export.php` から `rss_slots` の取り込みを削除し、互換のため DB 列は残すが今後参照しないようにした。 
- 既存のセキュリティ方針（`wp_nonce_field` / `current_user_can`、`wp_unslash`、サニタイズ、`$wpdb->prepare` 等）は維持したまま実装。 
- スロットの排他処理は行わず、複数サイトが同一スロットを共有できる仕様とした（既存の排他処理があれば無効化）。

### Testing
- 自動化されたテストは実行していません（未要求）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ac5c6ff48327a621918fd01d06ea)